### PR TITLE
Fix Windows incompatibility

### DIFF
--- a/1.6/Dockerfile
+++ b/1.6/Dockerfile
@@ -26,6 +26,4 @@ EXPOSE 443
 
 COPY run.sh run.sh
 
-RUN chmod +x run.sh
-
-CMD ["/run.sh"]
+ENTRYPOINT ["/bin/bash", "/run.sh"]

--- a/1.9-pagespeed/Dockerfile
+++ b/1.9-pagespeed/Dockerfile
@@ -77,6 +77,4 @@ EXPOSE 443
 
 COPY run.sh /run.sh
 
-RUN chmod +x /run.sh
-
-CMD ["/run.sh"]
+ENTRYPOINT ["/bin/bash", "/run.sh"]

--- a/1.9/Dockerfile
+++ b/1.9/Dockerfile
@@ -28,6 +28,4 @@ EXPOSE 443
 
 COPY run.sh /run.sh
 
-RUN chmod +x /run.sh
-
-CMD ["/run.sh"]
+ENTRYPOINT ["/bin/bash", "/run.sh"]


### PR DESCRIPTION
There is a problem with `CMD ["/run.sh"]` under Windows environment. The script needs to have executable permission and `chmod +x run.sh` doesn't work when boot2docker is used with Windows. 

The solution is to use `ENTRYPOINT ["/bin/bash", "/run.sh"]` because by default bash have executable permission.

See https://github.com/docker/compose/issues/2301
