### PR TITLE
1.9 pagespeed – Remove doubled HTTP real IP module, see #5

### DIFF
--- a/1.9-pagespeed/Dockerfile
+++ b/1.9-pagespeed/Dockerfile
@@ -51,8 +51,7 @@ RUN echo deb http://http.debian.net/debian jessie-backports main >> /etc/apt/sou
         --with-http_stub_status_module \
         --with-mail \
         --with-mail_ssl_module \
-        --with-file-aio \
-        --with-http_realip_module && \
+        --with-file-aio && \
     make && make install && \
     cd / && \
     rm -r ${BUILDDIR} && \


### PR DESCRIPTION
Removes double addition of `--with-http_realip_module`.
