### PR TITLE
[RFC] Fix for net::ERR CONTENT LENGTH MISMATCH

### DIFF
--- a/1.9/nginx.conf
+++ b/1.9/nginx.conf
@@ -23,7 +23,7 @@ http {
   gzip_disable "msie6";
   include /etc/nginx/conf.d/*.conf;
   include /etc/nginx/sites-enabled/*;
-  open_file_cache max=100;
+  open_file_cache off;
 }
 
 daemon off;


### PR DESCRIPTION
Nginx often throws the following error:

```
nginx_1  | 2017/08/30 08:59:51 [alert] 13#13: *1115 sendfile() failed (116: Stale file handle) while sending response to client, client: 172.17.8.1, server: , request: "GET /js/custom.js HTTP/1.1", host: "***", referrer: "***"
```
I suspect it's due to files syncing too slow and requesting it too fast after changing it. This causes the browser to throw a `net::ERR CONTENT LENGTH MISMATCH` error.

Disabling open_file_cache fixed it, I suspect it's because it doesn't incorrectly cache files that aren't fully synced yet. However, this may lead to slight performance reduction.